### PR TITLE
Update port in file MySQLconnector.py to allow connection to the server on localhost

### DIFF
--- a/MySQLconnector.py
+++ b/MySQLconnector.py
@@ -33,7 +33,7 @@ try:
                                            hostname,
                                                user=username,
                                                passwd=password,
-                                               port="3307",
+                                               port="3306",
                                                database=db_name)
 
         commands = database_entry.cursor()


### PR DESCRIPTION
# Description
The port number in file MySQLconnector.py was changed from 3307 to 3306

Fixes #8

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/KevinSkull/HydraFoods/blob/master/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
